### PR TITLE
#55 カラム名の調整

### DIFF
--- a/fho/workspace/src/main/java/com/example/demo/entity/Mark.java
+++ b/fho/workspace/src/main/java/com/example/demo/entity/Mark.java
@@ -14,7 +14,7 @@ import lombok.Data;
 public class Mark {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int markId;
+    private int id;
 
     @Column(nullable = false)
     private String mark;

--- a/fho/workspace/src/main/java/com/example/demo/entity/Stream.java
+++ b/fho/workspace/src/main/java/com/example/demo/entity/Stream.java
@@ -16,10 +16,10 @@ import lombok.Data;
 public class Stream {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int streamId;
+    private int id;
 
     @Column(nullable = false)
-    private int id;
+    private int fhoId;
 
     @Column(nullable = false)
     private Time time;

--- a/fho/workspace/src/main/java/com/example/demo/entity/StreamMark.java
+++ b/fho/workspace/src/main/java/com/example/demo/entity/StreamMark.java
@@ -15,7 +15,7 @@ public class StreamMark {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int streamMarkId;
+    private int id;
 	
     @Column(nullable = false)
     private int streamId;

--- a/fho/workspace/src/main/java/com/example/demo/repository/MarkRepository.java
+++ b/fho/workspace/src/main/java/com/example/demo/repository/MarkRepository.java
@@ -10,7 +10,7 @@ import com.example.demo.entity.Mark;
 
 @Repository
 public interface MarkRepository extends JpaRepository<Mark, Integer>{
-	@Query("select m.markId from Mark m where m.mark = ?1")
+	@Query("SELECT m.id FROM Mark m WHERE m.mark = ?1")
 	Optional<Integer> idFindByMark(String mark);
 	
 	public List<Mark> findAll();

--- a/fho/workspace/src/main/java/com/example/demo/repository/SearchRepository.java
+++ b/fho/workspace/src/main/java/com/example/demo/repository/SearchRepository.java
@@ -10,18 +10,18 @@ import com.example.demo.dto.SearchResultDTO;
 import com.example.demo.entity.Stream;
 
 public interface SearchRepository extends JpaRepository<Stream, Integer> {
-    @Query("SELECT Distinct new com.example.demo.dto.SearchResultDTO(d.id,  f.title, d.time, d.description, f.streamStart, m.mark) "
-    		+ "FROM Stream d LEFT JOIN Fho f ON d.id = f.id "
-    		+ "LEFT JOIN StreamMark sm ON d.streamId = sm.streamId "
-    		+ "LEFT JOIN Mark m ON sm.markId = m.markId "
+    @Query("SELECT Distinct new com.example.demo.dto.SearchResultDTO(f.id,  f.title, d.time, d.description, f.streamStart, m.mark) "
+    		+ "FROM Stream d LEFT JOIN Fho f ON d.fhoId = f.id "
+    		+ "LEFT JOIN StreamMark sm ON d.id = sm.streamId "
+    		+ "LEFT JOIN Mark m ON sm.markId = m.id "
     		+ "WHERE d.description LIKE CONCAT('%', :description, '%') AND f.title LIKE CONCAT('%', :title, '%') AND sm.markId = :markId "
     		+ "ORDER BY f.streamStart DESC")
     public Page<SearchResultDTO> searchStream(@Param("description") String description, @Param("title") String title,  @Param("markId") int markId, PageRequest pageable);
     
-    @Query("SELECT new com.example.demo.dto.SearchResultDTO(d.id,  f.title, d.time, d.description, f.streamStart, m.mark) "
-    		+ "FROM Stream d LEFT JOIN Fho f ON d.id = f.id "
-    		+ "LEFT JOIN StreamMark sm ON d.streamId = sm.streamId "
-    		+ "LEFT JOIN Mark m ON sm.markId = m.markId "
+    @Query("SELECT new com.example.demo.dto.SearchResultDTO(f.id,  f.title, d.time, d.description, f.streamStart, m.mark) "
+    		+ "FROM Stream d LEFT JOIN Fho f ON d.fhoId = f.id "
+    		+ "LEFT JOIN StreamMark sm ON d.id = sm.streamId "
+    		+ "LEFT JOIN Mark m ON sm.markId = m.id "
     		+ "WHERE d.description LIKE CONCAT('%', :description, '%') AND f.title LIKE CONCAT('%', :title, '%') "
     		+ "ORDER BY f.streamStart DESC")
     public Page<SearchResultDTO> searchOnlyKeywordStream(@Param("description") String description, @Param("title") String title,PageRequest pageable);

--- a/fho/workspace/src/main/java/com/example/demo/repository/StreamRepository.java
+++ b/fho/workspace/src/main/java/com/example/demo/repository/StreamRepository.java
@@ -11,7 +11,7 @@ import com.example.demo.entity.Stream;
 
 @Repository
 public interface StreamRepository extends JpaRepository<Stream, Integer> {
-	@Query("SELECT d FROM Stream d WHERE d.id = ?1")
+	@Query("SELECT d FROM Stream d WHERE d.fhoId = ?1")
 	public List<Stream> findByIdCustom(int id);
 	
 	@Query(value = "SELECT LAST_INSERT_ID()", nativeQuery = true)

--- a/fho/workspace/src/main/java/com/example/demo/service/MarkService.java
+++ b/fho/workspace/src/main/java/com/example/demo/service/MarkService.java
@@ -68,7 +68,7 @@ public class MarkService {
 		 Marks.clear();
 		 
 		 for(Mark mark: list) {
-			 Marks.put(mark.getMark(), mark.getMarkId());
+			 Marks.put(mark.getMark(), mark.getId());
 		 }
 		
 	}

--- a/fho/workspace/src/main/java/com/example/demo/service/StreamService.java
+++ b/fho/workspace/src/main/java/com/example/demo/service/StreamService.java
@@ -19,7 +19,7 @@ public class StreamService {
 	}
 	
 	public void setData(Stream stream, int id){
-		stream.setId(id);
+		stream.setFhoId(id);
 		streamRepository.save(stream);
 	}
 	

--- a/fho/workspace/src/main/resources/templates/search/index.html
+++ b/fho/workspace/src/main/resources/templates/search/index.html
@@ -15,9 +15,9 @@
 	            <option value="00"></option>
 	            <option
 	                th:each="mark : ${mark}"
-	                th:value="${mark.markId}"
+	                th:value="${mark.id}"
 	                th:text="${mark.mark}"
-	                th:selected="${mark.markId == selectedValue}">
+	                th:selected="${mark.id == selectedValue}">
 	            </option>
         	</select>
 <p><input id="sbtn1" type="submit" value="検索" /></p></form>


### PR DESCRIPTION
オートインクリメントの主キーカラム名を基本 id へ変更する
変更がすべてのプログラムをカバー出来ているかわからないので一旦pushしておきます

既にテーブルが存在する場合は下記のクエリで変更してから適用しないと余計なカラムができるしきちんと動作もしないかも

```
ALTER TABLE `mark_info`
CHANGE `mark_id` `id` int NOT NULL AUTO_INCREMENT FIRST
```

```
ALTER TABLE `stream_info`
CHANGE `stream_id` `id` int NOT NULL AUTO_INCREMENT FIRST,
CHANGE `id` `fho_id` int NOT NULL AFTER `description`
```

```
ALTER TABLE `stream_mark`
CHANGE `stream_mark_id` `id` int NOT NULL AUTO_INCREMENT FIRST
```